### PR TITLE
Refactor StudyContext and localize session state

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -22,8 +22,6 @@ export default function DashboardScreen() {
     dailyGoal,
     dailyProgressPercentage,
     currentSubject,
-    isSessionActive,
-    startSession,
   } = useStudy();
   const router = useRouter();
 
@@ -60,18 +58,6 @@ export default function DashboardScreen() {
   };
 
   const handleStartSession = () => {
-    if (isSessionActive) {
-      Alert.alert(
-        'Session Active',
-        'You already have an active study session. Would you like to go to it?',
-        [
-          { text: 'Cancel', style: 'cancel' },
-          { text: 'Go to Session', onPress: () => router.push('/session') },
-        ]
-      );
-      return;
-    }
-
     if (!currentSubject) {
       Alert.alert(
         'Select Subject',
@@ -83,7 +69,6 @@ export default function DashboardScreen() {
       return;
     }
 
-    startSession(currentSubject);
     router.push('/session');
   };
 
@@ -146,7 +131,7 @@ export default function DashboardScreen() {
                 fontWeight: '600',
               }}
             >
-              {isSessionActive ? "Go to Active Session" : "Start Study Session"}
+              Start Study Session
             </Text>
           </Pressable>
         </View>

--- a/src/components/SessionControls.js
+++ b/src/components/SessionControls.js
@@ -4,33 +4,38 @@ import { View, Text, Pressable, Alert, Modal, TextInput } from 'react-native';
 import Slider from '@react-native-community/slider';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '../context/ThemeContext';
-import { useStudy, SESSION_STATES } from '../context/StudyContext';
+
+export const SESSION_STATES = {
+  IDLE: 'idle',
+  ACTIVE: 'active',
+  PAUSED: 'paused',
+  BREAK: 'break',
+  COMPLETED: 'completed',
+};
 
 export default function SessionControls({
+  sessionState,
+  isSessionActive,
+  isSessionPaused,
+  isOnBreak,
+  currentSubject,
+  sessionDuration,
+  breakDuration,
+  onStartSession,
+  onPauseSession,
+  onResumeSession,
+  onEndSession,
+  onStartBreak,
+  onEndBreak,
+  onResetSession,
+  savePreferences,
   style = {},
   layout = 'horizontal', // 'horizontal' | 'vertical' | 'compact'
-  showSettingsButton = true,  // Changed from showSettings to showSettingsButton
+  showSettingsButton = true,
   showReset = true,
   onSessionEnd = null,
 }) {
   const { theme, globalStyles } = useTheme();
-  const {
-    sessionState,
-    isSessionActive,
-    isSessionPaused,
-    isOnBreak,
-    currentSubject,
-    sessionDuration,
-    breakDuration,
-    startSession,
-    pauseSession,
-    resumeSession,
-    endSession,
-    startBreak,
-    endBreak,
-    resetSession,
-    savePreferences,
-  } = useStudy();
 
   const [showSettings, setShowSettings] = useState(false);
   const [tempSessionLength, setTempSessionLength] = useState(Math.floor(sessionDuration / 60));
@@ -51,13 +56,13 @@ export default function SessionControls({
     }
 
     if (isSessionActive) {
-      pauseSession();
+      onPauseSession();
     } else if (isSessionPaused) {
-      resumeSession();
+      onResumeSession();
     } else if (isOnBreak) {
-      endBreak();
+      onEndBreak();
     } else {
-      startSession(currentSubject);
+      onStartSession(currentSubject);
     }
   };
 
@@ -66,7 +71,7 @@ export default function SessionControls({
     if (isSessionActive || isSessionPaused) {
       setShowEndSessionModal(true);
     } else {
-      endSession();
+      onEndSession();
       if (onSessionEnd) {
         onSessionEnd();
       }
@@ -77,7 +82,7 @@ export default function SessionControls({
   const confirmEndSession = () => {
     // Here you could save the focus score and notes to the session
     // For now, we'll just end the session
-    endSession();
+    onEndSession();
     setShowEndSessionModal(false);
     setFocusScore(5);
     setSessionNotes('');
@@ -117,13 +122,13 @@ export default function SessionControls({
             text: 'Reset',
             style: 'destructive',
             onPress: () => {
-              resetSession();
+              onResetSession();
             },
           },
         ]
       );
     } else {
-      resetSession();
+      onResetSession();
     }
   };
 
@@ -306,7 +311,7 @@ export default function SessionControls({
         {/* Start Break Button (if session active) */}
         {isSessionActive && (
           <Pressable
-            onPress={startBreak}
+            onPress={onStartBreak}
             style={({ pressed }) => [
               globalStyles.buttonSecondary,
               { flex: 1 },

--- a/src/components/TimerDisplay.js
+++ b/src/components/TimerDisplay.js
@@ -1,103 +1,52 @@
-// src/components/TimerDisplay.js
-import React, { useEffect, useState } from 'react';
-import { View, Text, Pressable } from 'react-native';
+import React from 'react';
+import { View, Text } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '../context/ThemeContext';
-import { useStudy, SESSION_STATES } from '../context/StudyContext';
 
-export default function TimerDisplay({ 
-  size = 'large', 
-  showControls = true, 
-  onTimeUpdate = null 
+export const SESSION_STATES = {
+  IDLE: 'idle',
+  ACTIVE: 'active',
+  PAUSED: 'paused',
+  BREAK: 'break',
+  COMPLETED: 'completed',
+};
+
+export default function TimerDisplay({
+  size = 'large',
+  timeRemaining = 0,
+  sessionDuration = 0,
+  breakDuration = 0,
+  sessionState = SESSION_STATES.IDLE,
+  progressPercentage = 0,
+  currentSubject = '',
 }) {
   const { theme, globalStyles } = useTheme();
-  const {
-    sessionState,
-    timeRemaining,
-    sessionDuration,
-    breakDuration,
-    progressPercentage,
-    currentSubject,
-    isSessionActive,
-    isSessionPaused,
-    isOnBreak,
-    startSession,
-    pauseSession,
-    resumeSession,
-    endSession,
-    startBreak,
-    endBreak,
-    updateTimer,
-  } = useStudy();
 
-  const [localTimeRemaining, setLocalTimeRemaining] = useState(timeRemaining);
-
-  // Timer effect
-  useEffect(() => {
-    let interval = null;
-
-    if (isSessionActive || isOnBreak) {
-      interval = setInterval(() => {
-        const newTimeRemaining = Math.max(0, localTimeRemaining - 1);
-        setLocalTimeRemaining(newTimeRemaining);
-        updateTimer(newTimeRemaining);
-        
-        if (onTimeUpdate) {
-          onTimeUpdate(newTimeRemaining);
-        }
-
-        // Auto-transition when timer reaches 0
-        if (newTimeRemaining === 0) {
-          if (isSessionActive) {
-            // Session completed, start break
-            endSession();
-            if (breakDuration > 0) {
-              startBreak();
-            }
-          } else if (isOnBreak) {
-            // Break completed
-            endBreak();
-          }
-        }
-      }, 1000);
-    }
-
-    return () => {
-      if (interval) {
-        clearInterval(interval);
-      }
-    };
-  }, [isSessionActive, isOnBreak, localTimeRemaining]);
-
-  // Sync with context when timeRemaining changes
-  useEffect(() => {
-    setLocalTimeRemaining(timeRemaining);
-  }, [timeRemaining]);
-
-  // Format time display
   const formatTime = (seconds) => {
     const hours = Math.floor(seconds / 3600);
     const minutes = Math.floor((seconds % 3600) / 60);
     const secs = seconds % 60;
-
     if (hours > 0) {
-      return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+      return `${hours.toString().padStart(2, '0')}:${minutes
+        .toString()
+        .padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
     }
-    return `${minutes.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+    return `${minutes.toString().padStart(2, '0')}:${secs
+      .toString()
+      .padStart(2, '0')}`;
   };
 
-  // Get timer color based on state and remaining time
   const getTimerColor = () => {
-    if (isOnBreak) return theme.colors.break;
-    if (isSessionPaused) return theme.colors.textSecondary;
-    
-    const percentage = (localTimeRemaining / sessionDuration) * 100;
+    if (sessionState === SESSION_STATES.BREAK) return theme.colors.break;
+    if (sessionState === SESSION_STATES.PAUSED)
+      return theme.colors.textSecondary;
+
+    const percentage = (timeRemaining / sessionDuration) * 100;
     if (percentage <= 10) return theme.colors.error;
     if (percentage <= 25) return theme.colors.warning;
     return theme.colors.focus;
   };
 
-  // Get session status text
   const getStatusText = () => {
     switch (sessionState) {
       case SESSION_STATES.ACTIVE:
@@ -113,7 +62,6 @@ export default function TimerDisplay({
     }
   };
 
-  // Get appropriate icon
   const getStatusIcon = () => {
     switch (sessionState) {
       case SESSION_STATES.ACTIVE:
@@ -129,20 +77,6 @@ export default function TimerDisplay({
     }
   };
 
-  // Handle control button press
-  const handleControlPress = () => {
-    if (isSessionActive) {
-      pauseSession();
-    } else if (isSessionPaused) {
-      resumeSession();
-    } else if (isOnBreak) {
-      endBreak();
-    } else {
-      startSession(currentSubject);
-    }
-  };
-
-  // Component styles based on size
   const getStyles = () => {
     const baseStyles = {
       container: {
@@ -166,16 +100,6 @@ export default function TimerDisplay({
         fontWeight: '500',
         marginBottom: 16,
       },
-      controlButton: {
-        backgroundColor: getTimerColor(),
-        borderRadius: 50,
-        padding: size === 'large' ? 16 : 12,
-        marginTop: 20,
-        alignItems: 'center',
-        justifyContent: 'center',
-        minWidth: size === 'large' ? 80 : 60,
-        minHeight: size === 'large' ? 80 : 60,
-      },
       progressContainer: {
         width: size === 'large' ? 200 : 150,
         height: 8,
@@ -191,7 +115,6 @@ export default function TimerDisplay({
       },
     };
 
-    // Size-specific text styles
     if (size === 'large') {
       baseStyles.timerText.fontSize = 56;
       baseStyles.statusText.fontSize = 18;
@@ -213,115 +136,35 @@ export default function TimerDisplay({
 
   return (
     <View style={styles.container}>
-      {/* Status Icon and Text */}
       <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 8 }}>
-        <Ionicons 
-          name={getStatusIcon()} 
-          size={size === 'large' ? 24 : 20} 
+        <Ionicons
+          name={getStatusIcon()}
+          size={size === 'large' ? 24 : 20}
           color={theme.colors.textSecondary}
           style={{ marginRight: 8 }}
         />
-        <Text style={styles.statusText}>
-          {getStatusText()}
-        </Text>
+        <Text style={styles.statusText}>{getStatusText()}</Text>
       </View>
 
-      {/* Subject Display */}
-      {currentSubject && (
-        <Text style={styles.subjectText}>
-          {currentSubject}
-        </Text>
-      )}
+      {currentSubject && <Text style={styles.subjectText}>{currentSubject}</Text>}
 
-      {/* Timer Display */}
-      <Text style={styles.timerText}>
-        {formatTime(localTimeRemaining)}
-      </Text>
+      <Text style={styles.timerText}>{formatTime(timeRemaining)}</Text>
 
-      {/* Progress Bar */}
-      {(isSessionActive || isSessionPaused || isOnBreak) && (
+      {(sessionState === SESSION_STATES.ACTIVE ||
+        sessionState === SESSION_STATES.PAUSED ||
+        sessionState === SESSION_STATES.BREAK) && (
         <View style={styles.progressContainer}>
-          <View 
+          <View
             style={[
-              styles.progressBar, 
-              { 
-                width: isOnBreak 
-                  ? `${((breakDuration - localTimeRemaining) / breakDuration) * 100}%`
-                  : `${progressPercentage}%`
-              }
-            ]} 
-          />
-        </View>
-      )}
-
-      {/* Session Info */}
-      {(isSessionActive || isSessionPaused) && (
-        <Text style={[globalStyles.textTertiary, { marginTop: 8, textAlign: 'center' }]}>
-          Session {Math.floor(((sessionDuration - localTimeRemaining) / sessionDuration) * 100)}% complete
-        </Text>
-      )}
-
-      {/* Control Buttons */}
-      {showControls && (
-        <View style={{ flexDirection: 'row', alignItems: 'center', marginTop: 20 }}>
-          {/* Main Control Button */}
-          <Pressable
-            onPress={handleControlPress}
-            style={({ pressed }) => [
-              styles.controlButton,
-              pressed && { opacity: 0.8, transform: [{ scale: 0.95 }] },
+              styles.progressBar,
+              {
+                width:
+                  sessionState === SESSION_STATES.BREAK
+                    ? `${((breakDuration - timeRemaining) / breakDuration) * 100}%`
+                    : `${progressPercentage}%`,
+              },
             ]}
-          >
-            <Ionicons 
-              name={
-                isSessionActive ? 'pause' :
-                isSessionPaused ? 'play' :
-                isOnBreak ? 'stop' : 'play'
-              }
-              size={size === 'large' ? 32 : 24}
-              color="#FFFFFF"
-            />
-          </Pressable>
-
-          {/* End Session Button (when active or paused) */}
-          {(isSessionActive || isSessionPaused) && (
-            <Pressable
-              onPress={endSession}
-              style={({ pressed }) => [
-                {
-                  backgroundColor: theme.colors.error,
-                  borderRadius: 30,
-                  padding: size === 'large' ? 12 : 10,
-                  marginLeft: 16,
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  minWidth: size === 'large' ? 60 : 50,
-                  minHeight: size === 'large' ? 60 : 50,
-                },
-                pressed && { opacity: 0.8, transform: [{ scale: 0.95 }] },
-              ]}
-            >
-              <Ionicons 
-                name="stop" 
-                size={size === 'large' ? 24 : 20} 
-                color="#FFFFFF" 
-              />
-            </Pressable>
-          )}
-        </View>
-      )}
-
-      {/* Quick Session Info */}
-      {sessionState === SESSION_STATES.IDLE && size === 'large' && (
-        <View style={{ marginTop: 16, alignItems: 'center' }}>
-          <Text style={[globalStyles.textSecondary, { textAlign: 'center', marginBottom: 8 }]}>
-            Ready for a {Math.floor(sessionDuration / 60)} minute focus session
-          </Text>
-          {!currentSubject && (
-            <Text style={[globalStyles.textTertiary, { textAlign: 'center' }]}>
-              Select a subject in settings to get started
-            </Text>
-          )}
+          />
         </View>
       )}
     </View>

--- a/src/context/StudyContext.js
+++ b/src/context/StudyContext.js
@@ -1,10 +1,8 @@
-// src/context/StudyContext.js
-import React, { createContext, useContext, useReducer, useEffect } from 'react';
+import React, { createContext, useContext, useState, useEffect } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const StudyContext = createContext();
 
-// Custom hook to use study context
 export const useStudy = () => {
   const context = useContext(StudyContext);
   if (!context) {
@@ -13,208 +11,61 @@ export const useStudy = () => {
   return context;
 };
 
-// Study session states
-export const SESSION_STATES = {
-  IDLE: 'idle',
-  ACTIVE: 'active',
-  PAUSED: 'paused',
-  BREAK: 'break',
-  COMPLETED: 'completed',
-};
-
-// Action types
-const ACTIONS = {
-  START_SESSION: 'START_SESSION',
-  PAUSE_SESSION: 'PAUSE_SESSION',
-  RESUME_SESSION: 'RESUME_SESSION',
-  END_SESSION: 'END_SESSION',
-  START_BREAK: 'START_BREAK',
-  END_BREAK: 'END_BREAK',
-  UPDATE_TIMER: 'UPDATE_TIMER',
-  UPDATE_ENVIRONMENT: 'UPDATE_ENVIRONMENT',
-  SET_SUBJECT: 'SET_SUBJECT',
-  SET_GOAL: 'SET_GOAL',
-  LOAD_PREFERENCES: 'LOAD_PREFERENCES',
-  RESET_SESSION: 'RESET_SESSION',
-};
-
-// Initial state
-const initialState = {
-  // Current session
-  sessionState: SESSION_STATES.IDLE,
-  currentSubject: '',
-  sessionDuration: 25 * 60, // 25 minutes in seconds
-  breakDuration: 5 * 60, // 5 minutes in seconds
-  timeRemaining: 25 * 60,
-  sessionStartTime: null,
-  pausedTime: 0,
-  
-  // Environment data
-  environment: {
-    lightLevel: null,
-    motionLevel: null,
-    lastChecked: null,
-    status: 'unknown', // 'optimal', 'good', 'poor', 'critical'
-    recommendations: [],
-  },
-  
-  // Session tracking
-  sessionsToday: 0,
-  totalTimeToday: 0,
-  currentStreak: 0,
-  dailyGoal: 4 * 60 * 60, // 4 hours in seconds
-  
-  // User preferences
-  preferences: {
-    defaultSessionLength: 25,
-    defaultBreakLength: 5,
-    enableEnvironmentAlerts: true,
-    enableMotionDetection: true,
-    autoStartBreaks: false,
-    soundEnabled: true,
-    vibrationEnabled: true,
-  },
-};
-
-// Reducer function
-const studyReducer = (state, action) => {
-  switch (action.type) {
-    case ACTIONS.START_SESSION:
-      return {
-        ...state,
-        sessionState: SESSION_STATES.ACTIVE,
-        sessionStartTime: Date.now(),
-        timeRemaining: state.sessionDuration,
-        pausedTime: 0,
-        currentSubject: action.payload.subject || state.currentSubject,
-      };
-      
-    case ACTIONS.PAUSE_SESSION:
-      return {
-        ...state,
-        sessionState: SESSION_STATES.PAUSED,
-        pausedTime: state.pausedTime + (Date.now() - state.sessionStartTime),
-      };
-      
-    case ACTIONS.RESUME_SESSION:
-      return {
-        ...state,
-        sessionState: SESSION_STATES.ACTIVE,
-        sessionStartTime: Date.now(),
-      };
-      
-    case ACTIONS.END_SESSION:
-      const sessionTime = state.sessionDuration - state.timeRemaining;
-      return {
-        ...state,
-        sessionState: SESSION_STATES.COMPLETED,
-        sessionsToday: state.sessionsToday + 1,
-        totalTimeToday: state.totalTimeToday + sessionTime,
-        currentStreak: state.currentStreak + 1,
-      };
-      
-    case ACTIONS.START_BREAK:
-      return {
-        ...state,
-        sessionState: SESSION_STATES.BREAK,
-        timeRemaining: state.breakDuration,
-        sessionStartTime: Date.now(),
-      };
-      
-    case ACTIONS.END_BREAK:
-      return {
-        ...state,
-        sessionState: SESSION_STATES.IDLE,
-        timeRemaining: state.sessionDuration,
-      };
-      
-    case ACTIONS.UPDATE_TIMER:
-      return {
-        ...state,
-        timeRemaining: Math.max(0, action.payload.timeRemaining),
-      };
-      
-    case ACTIONS.UPDATE_ENVIRONMENT:
-      return {
-        ...state,
-        environment: {
-          ...state.environment,
-          ...action.payload,
-          lastChecked: Date.now(),
-        },
-      };
-      
-    case ACTIONS.SET_SUBJECT:
-      return {
-        ...state,
-        currentSubject: action.payload.subject,
-      };
-      
-    case ACTIONS.SET_GOAL:
-      return {
-        ...state,
-        dailyGoal: action.payload.goal,
-      };
-      
-    case ACTIONS.LOAD_PREFERENCES:
-      return {
-        ...state,
-        preferences: { ...state.preferences, ...action.payload },
-        sessionDuration: (action.payload.defaultSessionLength || 25) * 60,
-        breakDuration: (action.payload.defaultBreakLength || 5) * 60,
-        timeRemaining: (action.payload.defaultSessionLength || 25) * 60,
-      };
-      
-    case ACTIONS.RESET_SESSION:
-      return {
-        ...state,
-        sessionState: SESSION_STATES.IDLE,
-        timeRemaining: state.sessionDuration,
-        sessionStartTime: null,
-        pausedTime: 0,
-        currentStreak: 0,
-      };
-      
-    default:
-      return state;
-  }
-};
-
-// Storage keys
 const PREFERENCES_KEY = '@study_focus_preferences';
 const DAILY_STATS_KEY = '@study_focus_daily_stats';
 
-export const StudyProvider = ({ children }) => {
-  const [state, dispatch] = useReducer(studyReducer, initialState);
+const defaultPreferences = {
+  defaultSessionLength: 25,
+  defaultBreakLength: 5,
+  enableEnvironmentAlerts: true,
+  enableMotionDetection: true,
+  autoStartBreaks: false,
+  soundEnabled: true,
+  vibrationEnabled: true,
+};
 
-  // Load preferences and daily stats on app start
+const defaultEnvironment = {
+  lightLevel: null,
+  motionLevel: null,
+  lastChecked: null,
+  status: 'unknown',
+  recommendations: [],
+};
+
+export const StudyProvider = ({ children }) => {
+  const [currentSubject, setCurrentSubject] = useState('');
+  const [dailyGoal, setDailyGoal] = useState(4 * 60 * 60); // 4 hours
+  const [sessionsToday, setSessionsToday] = useState(0);
+  const [totalTimeToday, setTotalTimeToday] = useState(0);
+  const [preferences, setPreferences] = useState(defaultPreferences);
+  const [environment, setEnvironment] = useState(defaultEnvironment);
+
   useEffect(() => {
     loadPreferences();
     loadDailyStats();
   }, []);
 
-  // Save daily stats when they change
   useEffect(() => {
     saveDailyStats();
-  }, [state.sessionsToday, state.totalTimeToday]);
+  }, [sessionsToday, totalTimeToday]);
 
   const loadPreferences = async () => {
     try {
-      const savedPreferences = await AsyncStorage.getItem(PREFERENCES_KEY);
-      if (savedPreferences) {
-        const preferences = JSON.parse(savedPreferences);
-        dispatch({ type: ACTIONS.LOAD_PREFERENCES, payload: preferences });
+      const saved = await AsyncStorage.getItem(PREFERENCES_KEY);
+      if (saved) {
+        const prefs = JSON.parse(saved);
+        setPreferences((p) => ({ ...p, ...prefs }));
       }
     } catch (error) {
       console.error('Error loading preferences:', error);
     }
   };
 
-  const savePreferences = async (newPreferences) => {
+  const savePreferences = async (newPrefs) => {
     try {
-      const updatedPreferences = { ...state.preferences, ...newPreferences };
-      await AsyncStorage.setItem(PREFERENCES_KEY, JSON.stringify(updatedPreferences));
-      dispatch({ type: ACTIONS.LOAD_PREFERENCES, payload: updatedPreferences });
+      const updated = { ...preferences, ...newPrefs };
+      await AsyncStorage.setItem(PREFERENCES_KEY, JSON.stringify(updated));
+      setPreferences(updated);
     } catch (error) {
       console.error('Error saving preferences:', error);
     }
@@ -223,17 +74,13 @@ export const StudyProvider = ({ children }) => {
   const loadDailyStats = async () => {
     try {
       const today = new Date().toDateString();
-      const savedStats = await AsyncStorage.getItem(DAILY_STATS_KEY);
-      if (savedStats) {
-        const { date, sessionsToday, totalTimeToday } = JSON.parse(savedStats);
+      const saved = await AsyncStorage.getItem(DAILY_STATS_KEY);
+      if (saved) {
+        const { date, sessionsToday: s, totalTimeToday: t } = JSON.parse(saved);
         if (date === today) {
-          // Same day, load existing stats
-          dispatch({ 
-            type: ACTIONS.LOAD_PREFERENCES, 
-            payload: { sessionsToday, totalTimeToday } 
-          });
+          setSessionsToday(s || 0);
+          setTotalTimeToday(t || 0);
         }
-        // Different day, stats reset automatically to 0
       }
     } catch (error) {
       console.error('Error loading daily stats:', error);
@@ -245,8 +92,8 @@ export const StudyProvider = ({ children }) => {
       const today = new Date().toDateString();
       const stats = {
         date: today,
-        sessionsToday: state.sessionsToday,
-        totalTimeToday: state.totalTimeToday,
+        sessionsToday,
+        totalTimeToday,
       };
       await AsyncStorage.setItem(DAILY_STATS_KEY, JSON.stringify(stats));
     } catch (error) {
@@ -254,87 +101,33 @@ export const StudyProvider = ({ children }) => {
     }
   };
 
-  // Action creators
-  const startSession = (subject = '') => {
-    dispatch({ type: ACTIONS.START_SESSION, payload: { subject } });
+  const updateEnvironment = (data) => {
+    setEnvironment((env) => ({ ...env, ...data, lastChecked: Date.now() }));
   };
 
-  const pauseSession = () => {
-    dispatch({ type: ACTIONS.PAUSE_SESSION });
-  };
+  const incrementSessionsToday = () => setSessionsToday((s) => s + 1);
+  const addToTotalTimeToday = (seconds) =>
+    setTotalTimeToday((t) => t + seconds);
 
-  const resumeSession = () => {
-    dispatch({ type: ACTIONS.RESUME_SESSION });
-  };
-
-  const endSession = () => {
-    dispatch({ type: ACTIONS.END_SESSION });
-  };
-
-  const startBreak = () => {
-    dispatch({ type: ACTIONS.START_BREAK });
-  };
-
-  const endBreak = () => {
-    dispatch({ type: ACTIONS.END_BREAK });
-  };
-
-  const updateTimer = (timeRemaining) => {
-    dispatch({ type: ACTIONS.UPDATE_TIMER, payload: { timeRemaining } });
-  };
-
-  const updateEnvironment = (environmentData) => {
-    dispatch({ type: ACTIONS.UPDATE_ENVIRONMENT, payload: environmentData });
-  };
-
-  const setSubject = (subject) => {
-    dispatch({ type: ACTIONS.SET_SUBJECT, payload: { subject } });
-  };
-
-  const setDailyGoal = (goal) => {
-    dispatch({ type: ACTIONS.SET_GOAL, payload: { goal } });
-  };
-
-  const resetSession = () => {
-    dispatch({ type: ACTIONS.RESET_SESSION });
-  };
-
-  // Computed values
-  const isSessionActive = state.sessionState === SESSION_STATES.ACTIVE;
-  const isSessionPaused = state.sessionState === SESSION_STATES.PAUSED;
-  const isOnBreak = state.sessionState === SESSION_STATES.BREAK;
-  const progressPercentage = ((state.sessionDuration - state.timeRemaining) / state.sessionDuration) * 100;
-  const dailyProgressPercentage = (state.totalTimeToday / state.dailyGoal) * 100;
+  const dailyProgressPercentage = (totalTimeToday / dailyGoal) * 100;
 
   const value = {
-    // State
-    ...state,
-    
-    // Computed values
-    isSessionActive,
-    isSessionPaused,
-    isOnBreak,
-    progressPercentage,
+    currentSubject,
+    dailyGoal,
+    sessionsToday,
+    totalTimeToday,
+    preferences,
+    environment,
     dailyProgressPercentage,
-    
-    // Actions
-    startSession,
-    pauseSession,
-    resumeSession,
-    endSession,
-    startBreak,
-    endBreak,
-    updateTimer,
-    updateEnvironment,
-    setSubject,
+    setSubject: setCurrentSubject,
     setDailyGoal,
-    resetSession,
     savePreferences,
+    updateEnvironment,
+    incrementSessionsToday,
+    addToTotalTimeToday,
   };
 
   return (
-    <StudyContext.Provider value={value}>
-      {children}
-    </StudyContext.Provider>
+    <StudyContext.Provider value={value}>{children}</StudyContext.Provider>
   );
 };


### PR DESCRIPTION
## Summary
- simplify `StudyContext` with `useState` instead of reducer
- remove session timer logic from context
- rewrite `TimerDisplay` and `SessionControls` to accept props
- manage timer and session state inside `SessionScreen`
- clean up dashboard start button

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688465c899c883309834496bd8e14fab